### PR TITLE
chore: Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup NodeJS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: 20
           cache: yarn
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -24,11 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup NodeJS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: 20
           cache: yarn
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       VERSION: ${{ steps.detect.outputs.VERSION }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Ensure commit is tagged
         id: detect
         run: |
@@ -33,12 +33,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup NodeJS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: 20
           cache: yarn
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "endOfLine": "auto"
+}

--- a/package.json
+++ b/package.json
@@ -116,5 +116,6 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "vscode-languageclient": "^9.0.1"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }


### PR DESCRIPTION
To fix the CI failure. Also some DX improvements for those using Windows so that Prettier lets git take care of line endings instead of forcing a specific format.