### PR TITLE
fix: number of prepend lines sent to LSP

### DIFF
--- a/src/commands/showPanel.tsx
+++ b/src/commands/showPanel.tsx
@@ -57,9 +57,10 @@ async function handleMessage(
           // @ts-ignore
           _.set(info, `["${activeEditor.uri}"].chapter`, message.chapter ?? 1);
           // TODO: message.prepend can be undefined in runtime, investigate
-          const nPrependLines = message.prepend
-            ? message.prepend.split("\n").length
-            : 0;
+          const nPrependLines =
+            message.prepend && message.prepend !== ""
+              ? message.prepend.split("\n").length + 2 // account for start/end markers
+              : 0;
           _.set(info, `["${activeEditor.uri}"].prepend`, nPrependLines);
           context.globalState.update("info", info);
           client.sendRequest("source/publishInfo", info);

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -65,12 +65,15 @@ export class Editor {
     const uri = vscode.Uri.file(filePath);
     self.uri = uri.toString();
 
-    const contents = [
-      "// PREPEND -- DO NOT EDIT",
-      prepend,
-      "// END PREPEND",
-      initialCode,
-    ].join("\n");
+    const contents =
+      prepend !== ""
+        ? [
+            "// PREPEND -- DO NOT EDIT",
+            prepend,
+            "// END PREPEND",
+            initialCode,
+          ].join("\n")
+        : initialCode;
 
     await vscode.workspace.fs.readFile(vscode.Uri.file(filePath)).then(
       () => null,


### PR DESCRIPTION
The extension tells the LSP server how many lines of code at prepended, which the LSP server uses to determine where to insert imports. The current implementation is bugged and does not consider the marker lines, causing the LSP to add auto imports inside the prepend section instead of below.