### PR TITLE
feat: better association of .js to Source

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
           "type": "string",
           "default": "https://frontend.cloud.heyzec.dedyn.io",
           "description": "URL to the Source Academy frontend"
+        },
+        "source-academy.workspaceFolder": {
+          "type": "string",
+          "default": ".sourceacademy",
+          "description": "Location to store code locally. If not absolute, it will be relative to the home directory."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,8 @@ import { setupStatusBar } from "./statusbar/status";
 import { registerAllCommands } from "./commands";
 import { activateLspClient, deactivateLspClient } from "./lsp/client";
 import { LanguageClient } from "vscode-languageclient/node";
+import { canonicaliseLocation } from "./utils/misc";
+import config from "./utils/config";
 
 // TODO: Don't expose this object directly, create an interface via a wrapper class
 export let client: LanguageClient;
@@ -34,6 +36,21 @@ export function activate(context: vscode.ExtensionContext) {
     "assets",
     "icon.svg",
   );
+
+  // TODO: Prompt the user to make this folder the default, and then set back to the config store.
+
+  // Update user's workspace settings to associate .js to Source
+  const workspaceFolder = canonicaliseLocation(config.workspaceFolder);
+  if (
+    vscode.workspace.workspaceFolders
+      ?.map((wf) => wf.uri.fsPath)
+      .includes(workspaceFolder)
+  ) {
+    const workspaceConfig = vscode.workspace.getConfiguration();
+    workspaceConfig.update("files.associations", {
+      "*.js": "source",
+    });
+  }
 }
 
 // This method is called when your extension is deactivated

--- a/src/utils/config/schema.ts
+++ b/src/utils/config/schema.ts
@@ -5,5 +5,8 @@ export default {
     type: "string",
     default: "https://frontend.cloud.heyzec.dedyn.io",
   },
-  workspaceFolder: { type: "string", default: "" },
+  workspaceFolder: {
+    type: "string",
+    default: ".sourceacademy",
+  },
 } satisfies Record<string, ConfigSchemaUnion>;

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -50,7 +50,6 @@ export class Editor {
     self.assessmentName = assessmentName;
     self.questionId = questionId;
 
-    // TODO: Prompt the user to make this folder the default, and then set back to the config store.
     const workspaceFolder = canonicaliseLocation(config.workspaceFolder);
 
     const filePath = path.join(

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -4,6 +4,7 @@ import * as os from "os";
 import config from "../utils/config";
 import { VscWorkspaceLocation } from "./messages";
 import path from "path";
+import { canonicaliseLocation } from "./misc";
 
 export class Editor {
   editor?: vscode.TextEditor;
@@ -49,13 +50,8 @@ export class Editor {
     self.assessmentName = assessmentName;
     self.questionId = questionId;
 
-    let workspaceFolder = config.workspaceFolder;
-    if (!workspaceFolder) {
-      workspaceFolder = path.join(os.homedir(), ".sourceacademy");
-      // TODO: Prompt the user to make this folder the default, and then set back to the config store.
-    } else if (!path.isAbsolute(workspaceFolder)) {
-      workspaceFolder = path.join(os.homedir(), workspaceFolder);
-    }
+    // TODO: Prompt the user to make this folder the default, and then set back to the config store.
+    const workspaceFolder = canonicaliseLocation(config.workspaceFolder);
 
     const filePath = path.join(
       workspaceFolder,

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -86,6 +86,7 @@ export class Editor {
       preview: false,
       viewColumn: vscode.ViewColumn.One,
     });
+    vscode.languages.setTextDocumentLanguage(editor.document, "source");
     editor.selection = new vscode.Selection(
       editor.document.positionAt(0),
       editor.document.positionAt(1),

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -1,0 +1,9 @@
+import path from "path";
+import * as os from "os";
+
+export function canonicaliseLocation(location: string) {
+  if (path.isAbsolute(location)) {
+    return location;
+  }
+  return path.join(os.homedir(), location);
+}


### PR DESCRIPTION
Typically, VS Code knows which LSP server to launch as the filetype is based on the extension of the file. We previously discussed and agreed that we do not want to create a custom file extension, e.g. `.sjs`, to represent Source.

To workaround this limitation, this PR uses to approaches:
1. Extension modifies workspace-specific `settings.json` for Source Academy folder, such that `.js` files here will now be associated with Source.
2. Regardless of which workspace the user's VS Code is in, editor buffers created by the extension will be programmatically set to Source.