### PR TITLE
feat: bump LSP version

### DIFF
--- a/scripts/lsp.js
+++ b/scripts/lsp.js
@@ -22,7 +22,7 @@ async function main() {
 
 async function downloadLsp() {
   const outputFolder = getOutputDir();
-  const version = "0.1.8";
+  const version = "0.1.9";
   const lspFilename = "source-lsp.js";
   const url = `https://github.com/source-academy/source-lsp/releases/download/v${version}/${lspFilename}`;
   // const url = `https://github.com/source-academy/source-lsp/releases/latest/download/${lspFilename}`;


### PR DESCRIPTION
I have released a new version of the LSP that fixes parameters in function and lambda definitions not being able to be renamed and detected on hover. This PR just bumps the LSP version to be downloaded