### PR TITLE
Upgraded lsp version to 0.1.10

### DIFF
--- a/scripts/lsp.js
+++ b/scripts/lsp.js
@@ -22,7 +22,7 @@ async function main() {
 
 async function downloadLsp() {
   const outputFolder = getOutputDir();
-  const version = "0.1.9";
+  const version = "0.1.10";
   const lspFilename = "source-lsp.js";
   const url = `https://github.com/source-academy/source-lsp/releases/download/v${version}/${lspFilename}`;
   // const url = `https://github.com/source-academy/source-lsp/releases/latest/download/${lspFilename}`;


### PR DESCRIPTION
This LSP version removes unused name warnings from the prepend